### PR TITLE
parcel moved to dev and ignoring dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#compiled code
+client/dist
+
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   },
   "homepage": "https://github.com/JamesFThomas/trailr#readme",
   "dependencies": {
-    "parcel-bundler": "^1.12.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
+  },
+  "devDependencies": {
+    "parcel-bundler": "^1.12.4"
   }
 }


### PR DESCRIPTION
Parcel bundler moved to a dev dependency and gitignore is now ignoring the dist folder